### PR TITLE
로테이션 챔피언 로직 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,10 +26,9 @@ export default function Home() {
           <div className="flex gap-[3.2rem] h-[30rem]">
             <LolMusicListContainer />
             <ContentBox titleText="로테이션 챔피언" css="flex-1">
-              {/* <RotationsList /> */}sss
+              <RotationsList />
             </ContentBox>
           </div>
-          <div></div>
         </div>
       </div>
     </div>

--- a/src/components/RotationsList.tsx
+++ b/src/components/RotationsList.tsx
@@ -8,7 +8,7 @@ export default async function RotationsList() {
   const championsData: any = await getChampionsData(true);
   const rotationsData = await getRotationsChampionsData();
   const [latestVersion] = await getVersionsData();
-  const renderItemArr = rotationsData.map(ids => {
+  const renderItemArr = rotationsData.freeChampionIds.map(ids => {
     return championsData.find((champion: any) => ids === Number(champion.key));
   });
   return (

--- a/src/service/requestJsonData.api.ts
+++ b/src/service/requestJsonData.api.ts
@@ -85,7 +85,7 @@ export async function getRotationsChampionsData() {
   });
   const rotationsData: RotationsDataType = await rotationsResponse.json();
 
-  return rotationsData.freeChampionIds;
+  return rotationsData;
 }
 
 export async function getSummonerData(name: string, tag: string) {


### PR DESCRIPTION
배포할 때 로테이션 컴포넌트 로직에 문제가 있어 임시로 비활성화 했다가 오류 수정 