### PR TITLE
전적 카드 툴팁 로직 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,6 +35,7 @@
 
 html {
   font-size: 62.5%;
+  position: relative;
 }
 
 @layer base {
@@ -283,6 +284,18 @@ html {
   }
   .arrow.rotate {
     transform: rotate(180deg);
+  }
+
+  .tooltip-box {
+    position: absolute;
+    padding: 1.2rem;
+    height: fit-content;
+    max-width: calc(20rem + 2.4rem);
+    z-index: 200000;
+    background-color: #2d2d2d;
+    transform: translateX(-45%);
+    border-radius: 0.4rem;
+    color: #fff;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,8 @@ import BackgroundProvider from '@/components/providers/BackgroundProvider';
 import ProgressProviders from '@/components/providers/ProgressBarProvider';
 import ReactQueryProviders from '@/components/providers/ReactQueryProviders';
 import ModalContainerProviders from '@/components/providers/ModalContainerProviders';
+import { TooltipProviders } from '@/components/providers/TooltipProviders';
+import TooltipContainerProviders from '@/components/providers/TooltipContainerProviders';
 
 const AppleSDGOdicNeo = localFont({
   src: [
@@ -66,8 +68,11 @@ export default async function RootLayout({
               <Header />
               <ReactQueryProviders>
                 <ModalsProvider>
-                  <ModalContainerProviders />
-                  {children}
+                  <TooltipProviders>
+                    <ModalContainerProviders />
+                    <TooltipContainerProviders />
+                    {children}
+                  </TooltipProviders>
                 </ModalsProvider>
               </ReactQueryProviders>
               <Footer />
@@ -75,6 +80,7 @@ export default async function RootLayout({
           </ProgressProviders>
         </BackgroundProvider>
         <div id="portal"></div>
+        <div id="tooltip"></div>
       </body>
     </html>
   );

--- a/src/components/providers/TooltipContainerProviders.tsx
+++ b/src/components/providers/TooltipContainerProviders.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useContext, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { TooltipStateContext } from './TooltipProviders';
+
+export default function TooltipContainerProviders() {
+  const { component: Component, props, target } = useContext(TooltipStateContext);
+  console.log(target);
+  const [position, setPosition] = useState<{ top: null | number; left: number | null }>({ top: null, left: null });
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (target && ref.current) {
+      const rect = target?.getBoundingClientRect();
+      setPosition({
+        top: rect?.top + window.scrollY - (ref.current?.offsetHeight + 10) || null,
+        left: rect?.left || null,
+      });
+    }
+  }, [target]);
+
+  if (Component === null) return null;
+
+  const portal = document.getElementById('tooltip') || document.createElement('div');
+
+  return createPortal(
+    <div ref={ref} className="tooltip-box" style={{ top: `${position.top}px`, left: `${position.left}px` }}>
+      <Component {...props} />
+    </div>,
+    portal,
+  );
+}

--- a/src/components/providers/TooltipProviders.tsx
+++ b/src/components/providers/TooltipProviders.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { createContext, useState } from 'react';
+
+export type TooltipState<T = {}> = {
+  component: React.ComponentType<T> | null;
+  props: T;
+  target: HTMLElement | null;
+};
+
+export const TooltipStateContext = createContext<TooltipState>({
+  component: null,
+  props: {},
+  target: null,
+});
+
+export const TooltipSetterContext = createContext<React.Dispatch<React.SetStateAction<TooltipState<any>>>>(() => {});
+
+export const TooltipProviders = ({ children }: { children: React.ReactNode }) => {
+  const [tooltipState, setTooltipState] = useState<TooltipState>({
+    component: null,
+    props: {},
+    target: null,
+  });
+
+  return (
+    <TooltipStateContext.Provider value={tooltipState}>
+      <TooltipSetterContext.Provider value={setTooltipState}>{children}</TooltipSetterContext.Provider>
+    </TooltipStateContext.Provider>
+  );
+};

--- a/src/components/recordcard/MainContent.tsx
+++ b/src/components/recordcard/MainContent.tsx
@@ -1,4 +1,5 @@
 import { DDRAGON_IMG_URL } from '@/constant/API';
+import useTooltip from '@/hook/useTooltip';
 import { ParticipantDtoType, PerkStyleDtoType } from '@/types/response';
 import {
   ChampionsDataType,
@@ -10,6 +11,9 @@ import {
 import imgSrcVersionLoader from '@/utils/imgSrcVersionLoader';
 import Image from 'next/image';
 import Link from 'next/link';
+import SummonerSpellTooltip from '../tooltipcontent/SummonerSpellTooltip';
+import ItemTooltip from '../tooltipcontent/ItemTooltip';
+import RuneTooltip from '../tooltipcontent/RuneTooltip';
 
 interface MainContentProps {
   participant: ParticipantDtoType;
@@ -44,13 +48,12 @@ export default function MainContent({ participant, version, gameVersion, data }:
               />
             </Link>
             <div className="flex gap-[0.2rem]">
-              <div className="flex flex-col gap-[0.2rem]">
-                <SummonerSpellImgRender
-                  summonerSpells={[participant.summoner1Id, participant.summoner2Id]}
-                  version={version}
-                  spellsData={data.summonerSpells}
-                />
-              </div>
+              <SummonerSpellImgRender
+                summonerSpells={[participant.summoner1Id, participant.summoner2Id]}
+                version={version}
+                spellsData={data.summonerSpells}
+              />
+
               <div className="flex flex-col gap-[0.2rem]">
                 <SummonerRunesImgRender
                   summonerRunes={participant.perks.styles}
@@ -131,8 +134,10 @@ function SummonerSpellImgRender({
     spellsData.find((spell: any) => id === Number(spell.key)),
   ) as SummonerSpellDataType[];
 
+  const { openTooltip, closeTooltip } = useTooltip();
+
   return (
-    <>
+    <div className="flex flex-col gap-[0.2rem]">
       {renderImgList.map(spell => (
         <img
           key={spell.key}
@@ -141,9 +146,13 @@ function SummonerSpellImgRender({
           height={22}
           alt={`${spell.name} 스펠 이미지`}
           className="rounded-[0.4rem]"
+          onMouseOver={e => {
+            openTooltip({ component: SummonerSpellTooltip, props: { data: spell }, target: e.target as HTMLElement });
+          }}
+          onMouseLeave={closeTooltip}
         />
       ))}
-    </>
+    </div>
   );
 }
 
@@ -164,23 +173,28 @@ function SummonerRunesImgRender({
     const matchRuneStyle = runeData.find(data => data.id === rune.style) as RuneDataType;
     if (index === 0) {
       const mainRune = matchRuneStyle.slots[0].runes?.find((data: any) => data.id === rune.selections[0].perk);
-      return mainRune?.icon || null;
+      return mainRune;
     }
-    return matchRuneStyle?.icon || null;
+    return matchRuneStyle;
   });
-
+  const { openTooltip, closeTooltip } = useTooltip();
   return (
     <>
-      {runeImgUrlList.map((rune: string | null, index) => {
+      {runeImgUrlList.map((rune, index) => {
         if (!rune) return <span key={index} className="w-[2.2rem] h-[2.2rem]"></span>;
+
         return (
           <img
-            key={rune}
-            src={`${DDRAGON_IMG_URL.RUNE}${rune}`}
+            key={rune.id}
+            src={`${DDRAGON_IMG_URL.RUNE}${rune?.icon}`}
             width={22}
             height={22}
             alt={`룬 이미지`}
             className={`${!index ? 'rounded-[50%] bg-color-gray-900' : ''}`}
+            onMouseOver={e => {
+              openTooltip({ component: RuneTooltip, props: { data: rune }, target: e.target as HTMLElement });
+            }}
+            onMouseLeave={closeTooltip}
           />
         );
       })}
@@ -203,7 +217,7 @@ function ItemImgRender({
     if (!itemId) return undefined;
     return itemsData[itemId];
   });
-
+  const { openTooltip, closeTooltip } = useTooltip();
   return (
     <div className="flex gap-[0.2rem]">
       {renderItemsArr.map((item, index) => {
@@ -225,6 +239,10 @@ function ItemImgRender({
             unoptimized
             alt={`${item.name}`}
             className="rounded-[0.4rem]"
+            onMouseOver={e => {
+              openTooltip({ component: ItemTooltip, props: { data: item }, target: e.target as HTMLElement });
+            }}
+            onMouseLeave={closeTooltip}
           />
         );
       })}

--- a/src/components/recordcard/RecordDetailContainer.tsx
+++ b/src/components/recordcard/RecordDetailContainer.tsx
@@ -1,8 +1,10 @@
 import { DDRAGON_IMG_URL } from '@/constant/API';
+import useTooltip from '@/hook/useTooltip';
 import { PerksDtoType } from '@/types/response';
 import { RuneDataType, RunesDataType } from '@/types/staticData';
 
 import Image from 'next/image';
+import RuneTooltip from '../tooltipcontent/RuneTooltip';
 
 interface RecordDetailContainerProps {
   isOpen: boolean;
@@ -22,6 +24,7 @@ export default function RecordDetailContainer({
 
   const { primaryStyle, subStyle } = checkingRune(runeData, perks);
 
+  const { openTooltip, closeTooltip } = useTooltip();
   return (
     <div className={`${isOpen ? '' : 'hidden'} bg-color-gray-00 min-h-[20rem] rounded-[0.8rem] overflow-hidden`}>
       <div className="px-[1.6rem] py-[1.2rem] bg-color-gray-100 text-[1.4rem] font-bold text-color-gray-500">
@@ -45,6 +48,10 @@ export default function RecordDetailContainer({
                     className={`${styleIndex === 0 ? 'rounded-[50%] bg-color-gray-200' : ''} ${
                       rune.check && styleIndex === 0 ? 'bg-color-primary-300' : ''
                     }`}
+                    onMouseOver={e => {
+                      openTooltip({ component: RuneTooltip, props: { data: rune }, target: e.target as HTMLElement });
+                    }}
+                    onMouseLeave={closeTooltip}
                   >
                     <img
                       src={`${DDRAGON_IMG_URL.RUNE}${rune.icon}`}
@@ -71,7 +78,13 @@ export default function RecordDetailContainer({
             {subStyle.slots.map((style, styleIndex) => (
               <div key={styleIndex} className="flex gap-[1.6rem]">
                 {style.map((rune, index) => (
-                  <div key={index}>
+                  <div
+                    key={index}
+                    onMouseOver={e => {
+                      openTooltip({ component: RuneTooltip, props: { data: rune }, target: e.target as HTMLElement });
+                    }}
+                    onMouseLeave={closeTooltip}
+                  >
                     <img
                       src={`${DDRAGON_IMG_URL.RUNE}${rune.icon}`}
                       width={32}

--- a/src/components/tooltipcontent/ItemTooltip.tsx
+++ b/src/components/tooltipcontent/ItemTooltip.tsx
@@ -1,0 +1,27 @@
+import { ImageDataType } from '@/types/staticData';
+
+interface ItemTooltipProps {
+  data: {
+    name: string;
+    description: string;
+    plaintext: string;
+    image: ImageDataType;
+    gold: {
+      base: number;
+      purchasable: boolean;
+      total: number;
+      sell: number;
+    };
+    tags: string[];
+  };
+}
+export default function ItemTooltip({ data }: ItemTooltipProps) {
+  return (
+    <div className="flex flex-col text-[1.2rem] min-w-[20rem]">
+      <strong className="text-[1.4rem] text-[#FFA500]">{data.name}</strong>
+      <p dangerouslySetInnerHTML={{ __html: data.description }} className="mb-[0.4rem]"></p>
+      <span>가격 : {data.gold.total.toLocaleString()}원</span>
+      <span>판매가격 : {data.gold.sell.toLocaleString()}원</span>
+    </div>
+  );
+}

--- a/src/components/tooltipcontent/RuneTooltip.tsx
+++ b/src/components/tooltipcontent/RuneTooltip.tsx
@@ -1,0 +1,19 @@
+interface RuneTooltipProps {
+  data: {
+    id: number;
+    key: string;
+    icon: string;
+    name: string;
+    shortDesc?: string;
+  };
+}
+
+export default function RuneTooltip({ data }: RuneTooltipProps) {
+  console.log(data);
+  return (
+    <div className={`flex flex-col text-[1.2rem] gap-[0.4rem] ${data?.shortDesc ? 'min-w-[20rem]' : ''}`}>
+      <strong className="text-[1.4rem] text-[#FFA500]">{data.name}</strong>
+      {data.shortDesc && <p dangerouslySetInnerHTML={{ __html: data.shortDesc }}></p>}
+    </div>
+  );
+}

--- a/src/components/tooltipcontent/SummonerSpellTooltip.tsx
+++ b/src/components/tooltipcontent/SummonerSpellTooltip.tsx
@@ -1,0 +1,19 @@
+import { SummonerSpellDataType } from '@/types/staticData';
+
+interface SummonerSpellTooltipProps {
+  data: SummonerSpellDataType;
+}
+
+export default function SummonerSpellTooltip({ data }: SummonerSpellTooltipProps) {
+  return (
+    <div className="flex flex-col gap-[0.8rem] text-[1.2rem]">
+      <strong className="text-[1.4rem] text-[#FFA500]">
+        {data.name}
+        <span className="text-[1.2rem]"> ({data.id})</span>
+      </strong>
+      <p>{data.description}</p>
+      <span>쿨타임 : {data.cooldownBurn}초</span>
+      <span></span>
+    </div>
+  );
+}

--- a/src/hook/useTooltip.tsx
+++ b/src/hook/useTooltip.tsx
@@ -1,0 +1,16 @@
+import { TooltipSetterContext, TooltipState } from '@/components/providers/TooltipProviders';
+import { useContext } from 'react';
+
+export default function useTooltip() {
+  const setTooltipState = useContext(TooltipSetterContext);
+
+  const openTooltip = <T,>({ component, props, target }: TooltipState<T>) => {
+    setTooltipState({ component, props, target });
+  };
+
+  const closeTooltip = () => {
+    setTooltipState({ component: null, props: {}, target: null });
+  };
+
+  return { openTooltip, closeTooltip };
+}

--- a/src/types/staticData.ts
+++ b/src/types/staticData.ts
@@ -1,4 +1,4 @@
-interface ImageDataType {
+export interface ImageDataType {
   full: string;
   sprite: string;
   group: string;
@@ -147,7 +147,7 @@ export interface RuneDataType {
   slots: RuneDetailDataType[];
 }
 
-interface RuneDetailDataType {
+export interface RuneDetailDataType {
   runes: {
     id: number;
     key: string;


### PR DESCRIPTION
1. 전적 카드에 툴팁 로직 구현
2. 전적 카드의 아이템이나 룬, 스펠에 MouseOver 를 하게 되면 각 콘텐츠에 맞는 설명 박스가 나옴