### PR TITLE
2차 리펙토링 및 구현

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,7 +5,7 @@ import '../globals.css';
 import Header from '@/components/common/header/Header';
 import Footer from '@/components/common/footer/Footer';
 
-import { getChampionsData, getItemsData, getSummonerSpellsData, getVersionsData } from '@/service/requestJsonData.api';
+import { getChampionsData, getVersionsData } from '@/service/requestJsonData.api';
 
 import { ModalsProvider } from '@/components/providers/ModalProvider';
 import BackgroundProvider from '@/components/providers/BackgroundProvider';
@@ -63,8 +63,6 @@ export default async function RootLayout({
 }>) {
   await getChampionsData(locale);
   await getVersionsData();
-  await getItemsData(locale);
-  await getSummonerSpellsData(locale);
 
   const messages = await getMessages();
   return (

--- a/src/components/SummonerProfile.tsx
+++ b/src/components/SummonerProfile.tsx
@@ -4,6 +4,7 @@ import imgSrcVersionLoader from '@/utils/imgSrcVersionLoader';
 import { getVersionsData } from '@/service/requestJsonData.api';
 import { AccountType, SummonerDataType } from '@/types/response';
 import { LanguageParamsType } from '@/types';
+import RefetchRecordDataButton from './recordcard/RefetchRecordDataButton';
 
 interface SummonerProfileProps {
   summonerData: AccountType & SummonerDataType;
@@ -29,7 +30,8 @@ export default async function SummonerProfile({ summonerData, language }: Summon
         </div>
         <div>
           <h1 className="text-[2.8rem] font-bold">{summonerData.gameName}</h1>
-          <span className="text-[2.4rem] text-color-gray-500">#{summonerData.tagLine}</span>
+          <div className="text-[2.4rem] text-color-gray-500">#{summonerData.tagLine}</div>
+          <RefetchRecordDataButton puuid={summonerData.puuid} />
         </div>
       </div>
       <ChampionMasteryContainer puuid={summonerData.puuid} language={language} />

--- a/src/components/SummonerRecordServerContainer.tsx
+++ b/src/components/SummonerRecordServerContainer.tsx
@@ -1,11 +1,4 @@
-import {
-  getChampionsData,
-  getItemsData,
-  getRunesData,
-  getSummonerGameRecordData,
-  getSummonerSpellsData,
-  getVersionsData,
-} from '@/service/requestJsonData.api';
+import { getVersionsData } from '@/service/requestJsonData.api';
 import { GameType, LanguageParamsType } from '@/types';
 import SummonerRecordClientContainer from './SummonerRecordClientContainer';
 
@@ -18,20 +11,7 @@ export default async function SummonerRecordServerContainer({
   gameType: GameType;
   language: LanguageParamsType;
 }) {
-  const championsData = await getChampionsData(language);
   const [latestVersion] = await getVersionsData();
-  const runesDataArr = await getRunesData(language);
-  const itemsData = await getItemsData(language);
-  const summonerSpellsData = await getSummonerSpellsData(language);
-  const summonerGameRecordData = await getSummonerGameRecordData(puuid, gameType);
 
-  return (
-    <SummonerRecordClientContainer
-      data={{ champions: championsData, runesArr: runesDataArr, summonerSpells: summonerSpellsData, items: itemsData }}
-      puuid={puuid}
-      latestVersion={latestVersion}
-      gameType={gameType}
-      initialData={summonerGameRecordData}
-    />
-  );
+  return <SummonerRecordClientContainer puuid={puuid} latestVersion={latestVersion} gameType={gameType} />;
 }

--- a/src/components/recordcard/CardLayer.tsx
+++ b/src/components/recordcard/CardLayer.tsx
@@ -9,13 +9,11 @@ export default function CardLayer({
   isWin,
   gameVersion,
   perks,
-  runesDataArr,
 }: {
   children: React.ReactNode;
   isWin: boolean;
   gameVersion: string;
   perks: PerksDtoType;
-  runesDataArr: RunesDataType[];
 }) {
   const [isOpen, setIsOpen] = useState(false);
   return (
@@ -35,7 +33,7 @@ export default function CardLayer({
           </span>
         </button>
       </div>
-      <RecordDetailContainer isOpen={isOpen} gameVersion={gameVersion} perks={perks} runesDataArr={runesDataArr} />
+      <RecordDetailContainer isOpen={isOpen} gameVersion={gameVersion} perks={perks} />
     </>
   );
 }

--- a/src/components/recordcard/RecordDetailContainer.tsx
+++ b/src/components/recordcard/RecordDetailContainer.tsx
@@ -1,27 +1,26 @@
 import { DDRAGON_IMG_URL } from '@/constant/API';
 import useTooltip from '@/hook/useTooltip';
 import { PerksDtoType } from '@/types/response';
-import { RuneDataType, RunesDataType } from '@/types/staticData';
+import { RuneDataType } from '@/types/staticData';
 
 import Image from 'next/image';
 import RuneTooltip from '../tooltipcontent/RuneTooltip';
 import { useTranslations } from 'next-intl';
+import { LanguageParamsType } from '@/types';
+import { useParams } from 'next/navigation';
+import useGetRuneData from '@/hook/query/useGetRuneData';
 
 interface RecordDetailContainerProps {
   isOpen: boolean;
   gameVersion: string;
   perks: PerksDtoType;
-  runesDataArr: RunesDataType[];
 }
 
-export default function RecordDetailContainer({
-  isOpen,
-  gameVersion,
-  perks,
-  runesDataArr,
-}: RecordDetailContainerProps) {
+export default function RecordDetailContainer({ isOpen, gameVersion, perks }: RecordDetailContainerProps) {
   const version = `${gameVersion.split('.').slice(0, 2).join('.')}.1`;
-  const { [version]: runeData } = runesDataArr.find(data => data[version]) as { [key: string]: RuneDataType[] };
+  const { locale }: { locale: LanguageParamsType } = useParams();
+
+  const { data: runeData } = useGetRuneData(version, locale);
 
   const { primaryStyle, subStyle } = checkingRune(runeData, perks);
   const t = useTranslations('recordDetailBox');

--- a/src/components/recordcard/RefetchRecordDataButton.tsx
+++ b/src/components/recordcard/RefetchRecordDataButton.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Loading from '@/assets/icons/loading.svg';
+
+export default function RefetchRecordDataButton({ puuid }: { puuid: string }) {
+  const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [disabled, setDisabled] = useState(true);
+  const [remainingTimeToRefetch, setRemainingTimeToRefetch] = useState(10);
+  useEffect(() => {
+    if (disabled) {
+      const timer = setTimeout(() => {
+        setDisabled(false);
+        setRemainingTimeToRefetch(0);
+      }, 1000 * 60 * 10);
+
+      const remainingTimer = setInterval(() => {
+        setRemainingTimeToRefetch(prev => {
+          if (prev === 1) {
+            clearInterval(remainingTimer);
+          }
+          return prev > 0 ? prev - 1 : 0;
+        });
+      }, 1000 * 60);
+
+      return () => {
+        clearInterval(remainingTimer);
+        clearTimeout(timer);
+      };
+    }
+  }, [disabled]);
+
+  const queueType = searchParams.get('queue_type') || 'TOTAL';
+  const handleRefetch = async () => {
+    setIsLoading(true);
+    await queryClient.refetchQueries({ queryKey: ['summonerRecordInfo', puuid, queueType] });
+    router.refresh();
+    setIsLoading(false);
+    setDisabled(true);
+    setRemainingTimeToRefetch(10);
+  };
+  return (
+    <div className="flex flex-col gap-[0.8rem] w-[10rem]">
+      <button
+        type="button"
+        onClick={handleRefetch}
+        className="px-[1.2rem] py-[0.8rem] bg-color-primary-500 text-[#fff] disabled:bg-gray-400 rounded-[0.4rem] text-[1.4rem]"
+        disabled={isLoading || disabled}
+      >
+        {isLoading ? (
+          <div className="loader">
+            <Loading />
+          </div>
+        ) : (
+          '전적 갱신'
+        )}
+      </button>
+      {remainingTimeToRefetch > 0 && (
+        <span className="self-center text-[1.2rem]">{`${remainingTimeToRefetch}분 후 갱신 가능`}</span>
+      )}
+    </div>
+  );
+}

--- a/src/components/skeleton/SummonerRecord.skeleton.tsx
+++ b/src/components/skeleton/SummonerRecord.skeleton.tsx
@@ -1,0 +1,12 @@
+export default function SummonerRecordSkeleton() {
+  return (
+    <div className="flex flex-col gap-[2.4rem]">
+      <div className="skeleton rounded-[0.8rem] h-[21.5rem]"></div>
+      <div className="flex flex-col gap-[0.8rem]">
+        {Array.from({ length: 10 }).map((_, index) => (
+          <div key={index} className="rounded-[0.4rem] h-[10.8rem] skeleton"></div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/hook/query/useGetChampionsData.ts
+++ b/src/hook/query/useGetChampionsData.ts
@@ -1,0 +1,23 @@
+import { DDRAGON_DATA_URL, REQUEST_LANGUAGE_MATCHER } from '@/constant/API';
+import { LanguageParamsType } from '@/types';
+import { ChampionsDataType } from '@/types/staticData';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export default function useGetChampionsData(version: string, lang: LanguageParamsType) {
+  const language = REQUEST_LANGUAGE_MATCHER[lang];
+  const requestUrl = DDRAGON_DATA_URL.CHAMPIONS.replace('{VERSION}', version).replace('{LANGUAGE}', language);
+
+  return useSuspenseQuery<{ version: string; data: ChampionsDataType[] }>({
+    queryKey: ['champions', version],
+    queryFn: async () => {
+      const { data } = await axios.get(requestUrl);
+      return {
+        version: data.version,
+        data: Object.values(data.data),
+      };
+    },
+    staleTime: Infinity,
+  });
+}

--- a/src/hook/query/useGetItemsData.ts
+++ b/src/hook/query/useGetItemsData.ts
@@ -1,0 +1,19 @@
+import { DDRAGON_DATA_URL, REQUEST_LANGUAGE_MATCHER } from '@/constant/API';
+import { LanguageParamsType } from '@/types';
+import formatGameVersion from '@/utils/formatGameVersion';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export default function useGetItemsData(gameVersion: string, lang: LanguageParamsType) {
+  const version = formatGameVersion(gameVersion);
+  const language = REQUEST_LANGUAGE_MATCHER[lang];
+  const requestUrl = DDRAGON_DATA_URL.ITEMS.replace('{VERSION}', version).replace('{LANGUAGE}', language);
+  return useSuspenseQuery({
+    queryKey: ['items', version],
+    queryFn: async () => {
+      const { data } = await axios.get(requestUrl);
+      return data;
+    },
+    staleTime: Infinity,
+  });
+}

--- a/src/hook/query/useGetRuneData.ts
+++ b/src/hook/query/useGetRuneData.ts
@@ -1,0 +1,20 @@
+import { DDRAGON_DATA_URL, REQUEST_LANGUAGE_MATCHER } from '@/constant/API';
+import { LanguageParamsType } from '@/types';
+import { RuneDataType } from '@/types/staticData';
+import formatGameVersion from '@/utils/formatGameVersion';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export default function useGetRuneData(gameVersion: string, lang: LanguageParamsType) {
+  const version = formatGameVersion(gameVersion);
+  const language = REQUEST_LANGUAGE_MATCHER[lang];
+  const requestUrl = DDRAGON_DATA_URL.RUNES.replace('{VERSION}', version).replace('{LANGUAGE}', language);
+  return useSuspenseQuery<RuneDataType[]>({
+    queryKey: ['rune', version],
+    queryFn: async () => {
+      const { data } = await axios.get(requestUrl);
+      return data;
+    },
+    staleTime: Infinity,
+  });
+}

--- a/src/hook/query/useGetSummonerRecordList.tsx
+++ b/src/hook/query/useGetSummonerRecordList.tsx
@@ -15,17 +15,13 @@ async function getSummonerRecordList({ pageParam = 1, puuid, type }: { pageParam
   return data;
 }
 
-export default function useGetSummonerRecordList(puuid: string, type: GameType, initialData: MatchDtoType[]) {
+export default function useGetSummonerRecordList(puuid: string, type: GameType) {
   const gameType = type || 'TOTAL';
 
   return useInfiniteQuery<MatchDtoType[]>({
     queryKey: ['summonerRecordInfo', puuid, gameType],
     queryFn: async ({ pageParam }) => await getSummonerRecordList({ pageParam, puuid, type: gameType }),
-    initialData: {
-      pages: [initialData],
-      pageParams: [0],
-    },
-    initialPageParam: 1,
+    initialPageParam: 0,
     getNextPageParam: (lastPage, pages) => {
       if (!lastPage || lastPage.length === 0) {
         return undefined;

--- a/src/hook/query/useGetSummonerSpellData.ts
+++ b/src/hook/query/useGetSummonerSpellData.ts
@@ -1,0 +1,20 @@
+import { DDRAGON_DATA_URL, REQUEST_LANGUAGE_MATCHER } from '@/constant/API';
+import { LanguageParamsType } from '@/types';
+import formatGameVersion from '@/utils/formatGameVersion';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import axios from 'axios';
+
+export default function useGetSummonerSpellData(gameVersion: string, lang: LanguageParamsType) {
+  const version = formatGameVersion(gameVersion);
+  const language = REQUEST_LANGUAGE_MATCHER[lang];
+  const requestUrl = DDRAGON_DATA_URL.SUMMONER_SPELLS.replace('{VERSION}', version).replace('{LANGUAGE}', language);
+
+  return useSuspenseQuery({
+    queryKey: ['summonerSpell', version],
+    queryFn: async () => {
+      const { data } = await axios.get(requestUrl);
+      return { version: data.version, data: Object.values(data.data) };
+    },
+    staleTime: Infinity,
+  });
+}

--- a/src/service/requestJsonData.api.ts
+++ b/src/service/requestJsonData.api.ts
@@ -43,21 +43,6 @@ export async function getChampionsData(lang: LanguageParamsType): Promise<Champi
   return Object.values(championsData.data);
 }
 
-export async function getSummonerSpellsData(lang: LanguageParamsType): Promise<SummonerSpellDataType[]> {
-  const [latestVersion] = await getVersionsData();
-  const language = REQUEST_LANGUAGE_MATCHER[lang];
-  const requestUrl = DDRAGON_DATA_URL.SUMMONER_SPELLS.replace('{VERSION}', latestVersion).replace(
-    '{LANGUAGE}',
-    language,
-  );
-
-  const summonerSpellsResponse = await fetch(requestUrl);
-
-  const { data } = await summonerSpellsResponse.json();
-
-  return Object.values(data);
-}
-
 export async function getChampionData(champName: string, lang: LanguageParamsType): Promise<ChampionDataType> {
   const [latestVersion] = await getVersionsData();
   const language = REQUEST_LANGUAGE_MATCHER[lang];
@@ -70,18 +55,6 @@ export async function getChampionData(champName: string, lang: LanguageParamsTyp
   const { data } = await championResponse.json();
 
   return data[champName];
-}
-
-export async function getItemsData(lang: LanguageParamsType): Promise<ItemsDataType> {
-  const [latestVersion] = await getVersionsData();
-  const language = REQUEST_LANGUAGE_MATCHER[lang];
-  const requestUrl = DDRAGON_DATA_URL.ITEMS.replace('{VERSION}', latestVersion).replace('{LANGUAGE}', language);
-
-  const itemsResponse = await fetch(requestUrl);
-
-  const { data } = await itemsResponse.json();
-
-  return data;
 }
 
 export async function getCommunityChampionData(id: string): Promise<CommunityChampionDataType> {
@@ -130,29 +103,4 @@ export async function getSummonerLeagueData(summonerId: string): Promise<LeagueD
   const summonerLeagueData = await summonerLeagueResponse.json();
 
   return summonerLeagueData;
-}
-
-export async function getRunesData(lang: LanguageParamsType): Promise<RunesDataType[]> {
-  const versionData = await getVersionsData();
-  const versionSliceArr = versionData.slice(0, 5);
-  const language = REQUEST_LANGUAGE_MATCHER[lang];
-  const runeDataArr = await Promise.all(
-    versionSliceArr.map(async (version: string) => {
-      const requestUrl = DDRAGON_DATA_URL.RUNES.replace('{VERSION}', version).replace('{LANGUAGE}', language);
-      const responseData = await fetch(requestUrl);
-      const runesData = await responseData.json();
-      return { [version]: runesData };
-    }),
-  );
-  return runeDataArr;
-}
-
-export async function getSummonerGameRecordData(puuid: string, gameType?: GameType): Promise<MatchDtoType[]> {
-  const dataResponse = await fetch(
-    `${SERVER_REQUEST_URL.SUMMONER_RECORD_DATA}${puuid}${gameType ? `?type=${gameType}` : ''} `,
-    { next: { tags: ['record', puuid] } },
-  );
-
-  const recordData = await dataResponse.json();
-  return recordData;
 }

--- a/src/utils/formatGameVersion.ts
+++ b/src/utils/formatGameVersion.ts
@@ -1,0 +1,4 @@
+export default function formatGameVersion(gameVersion: string) {
+  const foramtVersion = `${gameVersion.split('.').slice(0, 2).join('.')}.1`;
+  return foramtVersion;
+}


### PR DESCRIPTION
1. 전적 데이터에 필요한 추가 데이터(룬, 챔피언, 스펠)를 client에서 호출하여 렌더링하도록 변경 => 전적 검색 페이지 렌더링 속도 향상
2. 전적 갱신 버튼 로직 추가 => 무분별한 refetching을 막기위해 초기 렌더링 10분 이후 다시 전적갱신이 가능함